### PR TITLE
feat(digest): add narrative intro paragraph

### DIFF
--- a/.claude/skills/ai-digest/SKILL.md
+++ b/.claude/skills/ai-digest/SKILL.md
@@ -131,6 +131,8 @@ items: <total items after dedup>
 
 > <total items> items from <sources count> sources
 
+<intro paragraph>
+
 ## 🔥 Hot
 - **<catchy headline>** — <summary>. [<source>](url)
 
@@ -147,6 +149,16 @@ items: <total items after dedup>
 ## 🔧 DevTools / Releases
 - ...
 ```
+
+### Intro paragraph
+
+Before the categorized sections, write a short narrative intro paragraph (2–4 sentences) that:
+- Synthesizes the **Hot** items into a cohesive narrative — identify themes, connections, or why today's news matters
+- Uses an **editorial, opinionated tone** — not a dry summary but a take: what's exciting, what's worth watching, what might break things
+- Explains **why** these items are significant, not just what happened
+- Ends with a natural transition into the full digest
+- Written in the configured language
+- Plain prose, no headers, no bullet points, no emoji
 
 The **Hot** category is mandatory and must always be present. Skip any other category that has zero items.
 

--- a/.claude/skills/ai-digest/SKILL.md
+++ b/.claude/skills/ai-digest/SKILL.md
@@ -152,13 +152,14 @@ items: <total items after dedup>
 
 ### Intro paragraph
 
-Before the categorized sections, write a short narrative intro paragraph (2–4 sentences) that:
+Before the categorized sections, write a narrative intro (2–4 short paragraphs) that:
 - Synthesizes the **Hot** items into a cohesive narrative — identify themes, connections, or why today's news matters
 - Uses an **editorial, opinionated tone** — not a dry summary but a take: what's exciting, what's worth watching, what might break things
 - Explains **why** these items are significant, not just what happened
 - Ends with a natural transition into the full digest
 - Written in the configured language
 - Plain prose, no headers, no bullet points, no emoji
+- **Break into short paragraphs** (1–2 sentences each) for easy scanning — avoid walls of text
 
 The **Hot** category is mandatory and must always be present. Skip any other category that has zero items.
 


### PR DESCRIPTION
## Summary
- Adds prompt instructions to SKILL.md for generating a 2-4 sentence editorial intro at the top of each digest
- Intro synthesizes 🔥 Hot items into a cohesive narrative with an opinionated, editorial tone
- No code changes — purely a prompt update to the ai-digest skill

Closes #5

## Test plan
- [ ] Run `/ai-digest` and verify intro paragraph appears between the subtitle and first section
- [ ] Confirm intro is prose (not bullets), 2-4 sentences, in the configured language
- [ ] Confirm intro reflects Hot items accurately with editorial voice

🤖 Generated with [Claude Code](https://claude.com/claude-code)