### PR TITLE
fix(ci): close typecheck and lint gaps exposed by dep bump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,10 @@ jobs:
       - run: npm ci
 
       - name: Biome check
-        run: npx biome check
+        run: npx biome check --error-on-warnings
+
+      - name: Typecheck
+        run: npx tsc --noEmit
 
       - name: Run tests
         run: npm test

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/biome.json
+++ b/biome.json
@@ -13,12 +13,6 @@
     "indentStyle": "space",
     "indentWidth": 2
   },
-  "linter": {
-    "enabled": true,
-    "rules": {
-      "preset": "recommended"
-    }
-  },
   "javascript": {
     "formatter": {
       "quoteStyle": "single"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,11 +15,14 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.5",
-        "@types/node": "^26.1.1",
+        "@types/node": "^24.13.3",
         "husky": "^9.1.7",
         "lint-staged": "^17.2.0",
         "typescript": "^7.0.2",
         "vitest": "^4.1.10"
+      },
+      "engines": {
+        "node": ">=24"
       }
     },
     "node_modules/@biomejs/biome": {
@@ -645,13 +648,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
-      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~8.3.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@typescript/typescript-aix-ppc64": {
@@ -2853,9 +2856,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
-      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "ai-digest-mcp",
   "version": "0.1.5",
   "type": "module",
+  "engines": {
+    "node": ">=24"
+  },
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
@@ -18,7 +21,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.5",
-    "@types/node": "^26.1.1",
+    "@types/node": "^24.13.3",
     "husky": "^9.1.7",
     "lint-staged": "^17.2.0",
     "typescript": "^7.0.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "declaration": true,
+    // Required since TS 7 (@types/node is no longer auto-included). This is an
+    // allowlist: any future ambient @types/* package must be added here too.
     "types": ["node"]
   },
   "include": ["src"],


### PR DESCRIPTION
Follow-up to #7. The dependency bump passed CI, but reviewing it surfaced that CI was never checking the things the bump changed.

## Findings fixed

| # | Issue | Fix |
|---|---|---|
| 1 | **CI never ran `tsc`.** The only compile was `npm run build` inside the Dockerfile, in the tag-gated `docker` job — so the TS 5.9 → 7.0 jump was validated by nothing on PRs. A type break would have surfaced only after `/release` pushed a tag, failing `docker`, skipping `release` (`needs: [quality, docker]`), and leaving a permanently draft GitHub Release with no archive or `install.sh`. | Added a `tsc --noEmit` step to the `quality` job. |
| 2 | **Biome warnings could not fail the build.** The `recommended` preset emits warn-level diagnostics (`suspicious/noExplicitAny` etc.) and `biome check` exits 0 on warnings, so that whole class of defect merged green. | `biome check --error-on-warnings`. |
| 3 | **`@types/node` sat two majors above the runtime** (`^26` vs Node 24 in CI and `node:24-alpine` in the Dockerfile), so the compiler stopped rejecting APIs the runtime lacks — a Node 25/26 builtin typechecked clean and crashed with `ERR_UNKNOWN_BUILTIN_MODULE` in the published image. | Pinned to `^24`. |
| 4 | **`lint-staged@17` raised the Node floor to `>=22.22.1`, but there was no `engines` field**, so an under-versioned `npm ci` only warned (EBADENGINE) and then the husky pre-commit hook crashed instead of formatting. | `engines: { node: ">=24" }` matching the Dockerfile and CI pin, plus `.npmrc` `engine-strict=true` so it fails install rather than warning. |
| 5 | **`linter.rules.preset: "recommended"` restated Biome's default** — a config block that changed no diagnostics, yet went stale and cost a migration commit on the last minor bump. | Deleted the block. |
| 6 | **`types: ["node"]` is load-bearing but silently exclusionary** — it's required since TS 7 (removing it gives 14 `TS2591` errors), but as an allowlist it also opts out every future ambient `@types/*` package, and the resulting error points at the consuming file, not at this line. | Documented in place. Kept, since it's required. |

## Verification

- `biome check --error-on-warnings`, `tsc --noEmit`, `npm test` (65 tests, 8 files) — all pass on this branch.
- Both new gates confirmed to actually bite: a probe file with `(a: any)` and `const g: number = "x"` exits **1** from both biome and tsc (before this change, biome exited 0 and tsc never ran in CI).
- `npm ci` verified to still succeed with `engine-strict=true` on Node 24.