### PR TITLE
feat(logging): capture why a run dies

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,9 +137,16 @@ GITHUB_TOKEN=ghp_your_token_here
 # View latest digest
 cat "$(ls -1t ~/digests/*.md | head -1)"
 
-# Check logs
+# Watch this run's digest output
 tail -f logs/$(date +%Y-%m-%d).md
+
+# Diagnose a crash (process start/exit, tool errors, signals)
+tail -f logs/run.log
 ```
+
+When a run dies, `logs/run.log` is the file to read. Exit codes: `2` docker
+missing, `3` Docker daemon down, `137` killed (usually OOM), `143` terminated.
+A run with no `exiting code=` line was killed outright rather than crashing.
 
 ## Development
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-set -euo pipefail
+# -E so the ERR trap survives into functions and subshells
+set -Eeuo pipefail
 
 REPO="kalinichenko88/ai-digest"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -9,6 +10,23 @@ if [ -f "${SCRIPT_DIR}/.version" ]; then
 else
   PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 fi
+
+# --- Diagnostics ---
+# Launchers like Shortcuts and cron discard stderr and show only an exit code,
+# so anything failing before the run starts left no trace at all.
+LOG_DIR="$PROJECT_DIR/logs"
+RUN_LOG="$LOG_DIR/run.log"
+mkdir -p "$LOG_DIR"
+
+runlog() { echo "[$(date '+%Y-%m-%d %H:%M')] [$$] $1" >> "$RUN_LOG"; }
+
+# Keep stderr on screen when interactive, capture it otherwise.
+[ -t 2 ] || exec 2>> "$RUN_LOG"
+trap 'runlog "run.sh died at line $LINENO: $BASH_COMMAND (exit $?)"' ERR
+
+# PATH is the usual difference between a working terminal run and a failing
+# Shortcuts one — Shortcuts starts a shell without your profile.
+runlog "start claude=$(command -v claude || echo MISSING) docker=$(command -v docker || echo MISSING) PATH=$PATH"
 
 # --- Update subcommand ---
 if [ "${1:-}" = "update" ]; then
@@ -154,12 +172,22 @@ HELPER
 fi
 
 # --- Default: run digest ---
-LOG_DIR="$PROJECT_DIR/logs"
 LOG_FILE="$LOG_DIR/$(date +%Y-%m-%d).md"
 
-mkdir -p "$LOG_DIR"
-
 cd "$PROJECT_DIR"
+
+# The MCP server runs in a container: no daemon means no tools and no server-side
+# log either. Distinct exit codes so the launcher shows a diagnosis, not "exit 1".
+if grep -q '"docker"' "$PROJECT_DIR/.claude/settings.json" 2>/dev/null; then
+  if ! command -v docker >/dev/null; then
+    runlog "docker not found in PATH"
+    exit 2
+  fi
+  if ! docker info >/dev/null 2>&1; then
+    runlog "Docker daemon not running"
+    exit 3
+  fi
+fi
 
 START_TIME=$(date +%s)
 
@@ -187,5 +215,12 @@ END_TIME=$(date +%s)
 ELAPSED=$(( END_TIME - START_TIME ))
 
 echo "[$(date '+%Y-%m-%d %H:%M')] Finished with exit code $EXIT_CODE (${ELAPSED}s elapsed)" >> "$LOG_FILE"
+runlog "finished exit=$EXIT_CODE elapsed=${ELAPSED}s"
+
+# 137 = SIGKILL (OOM), 143 = SIGTERM
+if [ "$EXIT_CODE" -ne 0 ] && command -v osascript >/dev/null; then
+  osascript -e "display notification \"exit $EXIT_CODE — see logs/run.log\" with title \"ai-digest failed\"" >/dev/null 2>&1 || true
+fi
+
 echo "Done (${ELAPSED}s, exit code $EXIT_CODE)"
 exit $EXIT_CODE

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -4,6 +4,9 @@ import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const LOG_DIR = join(__dirname, '..', 'logs');
+// Single append-only file: dated logs/*.md hold Claude's digest output, this
+// holds process diagnostics. One path to tail when something dies.
+const LOG_FILE = join(LOG_DIR, 'run.log');
 
 if (!process.env.VITEST) {
   mkdirSync(LOG_DIR, { recursive: true });
@@ -16,7 +19,9 @@ function timestamp(): string {
 
 export function log(tag: string, message: string): void {
   if (process.env.VITEST) return;
-  const ts = timestamp();
-  const logFile = join(LOG_DIR, `${ts.slice(0, 10)}.md`);
-  appendFileSync(logFile, `[${ts}] [${tag.padEnd(13)}] ${message}\n`);
+  // pid tells apart concurrent server instances and respawns
+  appendFileSync(
+    LOG_FILE,
+    `[${timestamp()}] [${process.pid}] [${tag.padEnd(13)}] ${message}\n`,
+  );
 }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -40,6 +40,33 @@ const server = new McpServer({
   version: pkg.version,
 });
 
+// Wrap once here instead of in each handler: the SDK turns a thrown handler
+// into a client-side error response, so without this a failing tool leaves no
+// trace in the log at all. Timing catches the "it just hung" case.
+type ToolHandler = (...args: unknown[]) => Promise<unknown>;
+
+const registerTool = server.registerTool.bind(server) as (
+  name: string,
+  config: unknown,
+  handler: ToolHandler,
+) => unknown;
+
+server.registerTool = ((name: string, config: unknown, handler: ToolHandler) =>
+  registerTool(name, config, async (...args) => {
+    const start = Date.now();
+    try {
+      const result = await handler(...args);
+      log(name, `ok in ${Date.now() - start}ms`);
+      return result;
+    } catch (err) {
+      log(
+        name,
+        `FAILED after ${Date.now() - start}ms: ${err instanceof Error ? err.stack : err}`,
+      );
+      throw err;
+    }
+  })) as typeof server.registerTool;
+
 server.registerTool(
   'fetch_rss',
   {
@@ -204,6 +231,26 @@ server.registerTool(
   },
 );
 
+// Death hooks. A missing "exiting code=" line is itself the diagnosis: the
+// process was SIGKILLed (OOM, docker stop timeout, kill -9).
+process.on('uncaughtException', (err) => {
+  log('mcp', `uncaughtException: ${err.stack ?? err}`);
+  process.exit(1);
+});
+process.on('unhandledRejection', (reason) => {
+  log(
+    'mcp',
+    `unhandledRejection: ${reason instanceof Error ? reason.stack : reason}`,
+  );
+});
+for (const signal of ['SIGTERM', 'SIGINT', 'SIGHUP'] as const) {
+  process.on(signal, () => {
+    log('mcp', `got ${signal}`);
+    process.exit(0);
+  });
+}
+process.on('exit', (code) => log('mcp', `exiting code=${code}`));
+
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
@@ -211,6 +258,7 @@ async function main() {
 }
 
 main().catch((err) => {
-  log('mcp', `Fatal error: ${err}`);
+  log('mcp', `Fatal error: ${err instanceof Error ? err.stack : err}`);
   console.error(err);
+  process.exit(1);
 });


### PR DESCRIPTION
## Problem

A run launched from Mac Shortcuts shows only `process exit 1`, with nowhere to look for the cause:

- `run.sh`'s own stderr goes nowhere — anything failing before the run starts (`set -e`, `cd`, `claude` not on PATH) vanishes without a trace
- process death was never logged: `main().catch` only catches a startup failure
- a throw inside any of the 6 tools is turned by the SDK into a client-side error response — nothing reaches the log
- if Docker Desktop isn't up, the server's container never starts, so the logger inside it never runs a single line

## Changes

**`logs/run.log`** — one append-only file for process diagnostics, pid on every line (three consecutive "Initializing MCP server" entries are no longer a riddle: you can see whether it's one instance or three). Dated `logs/*.md` stay Claude's digest output.

**`mcp-server.ts`** — hooks for `uncaughtException`, `unhandledRejection`, `SIGTERM/SIGINT/SIGHUP` and `exit`. A missing `exiting code=` line is itself the diagnosis: the process was SIGKILLed (OOM, `kill -9`).

**Tool registration wrapper** — one patch at the shared choke point instead of editing six handlers. Logs the stack of a failing tool and the duration of each call (`ok in 4ms` explains both "it hung" and timeouts).

**`run.sh`** — `trap ERR` reporting line number and command, stderr captured when there's no tty, a start line with `PATH`/`claude`/`docker` (the usual difference between a working terminal and a failing Shortcuts run), a docker preflight with distinct exit codes 2 and 3, and a macOS notification on non-zero exit.

## Verified live

| Scenario | Result in `logs/run.log` |
|---|---|
| Normal stdio session | `[70237] [fetch_previous_urls] ok in 4ms` → `exiting code=0` |
| `kill -TERM` | `got SIGTERM` → `exiting code=0` |
| Failing tool (moved `sources.yml` away) | `[fetch_all_rss] FAILED after 0ms: Error: ENOENT...` plus stack |
| `PATH` without docker (what Shortcuts effectively does) | `start claude=MISSING docker=MISSING PATH=...` → `docker not found in PATH`, exit **2** instead of exit 1 |

`npm run build`, `npm test` (66 tests), biome and `bash -n` all green.

## Skipped

Log levels, rotation, JSON format, a separate error file. Add them if the first caught crash doesn't give enough to go on.